### PR TITLE
✨ add zizmor workflow security analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: Workflow security analysis
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  zizmor:
+    name: zizmor
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    uses: Spillgebees/admin/.github/workflows/zizmor.yml@a71d815a53f77f9cabca802b4bd9b69fe2fcd96e # main


### PR DESCRIPTION
## Summary

Adds a thin caller for the reusable [zizmor](https://docs.zizmor.sh/) workflow from `Spillgebees/admin` (added in Spillgebees/admin#6). zizmor statically analyzes GitHub Actions workflows for security issues (template injection, credential persistence, unpinned actions, excessive permissions, …). Findings are uploaded as SARIF and appear under **Security → Code scanning**.

## Current baseline

Local run of zizmor v1.25.2 against this repo's workflows reports: **5 medium** (3× [`artipacked`](https://docs.zizmor.sh/audits/#artipacked), 2× [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions)) and 1 informational ([`use-trusted-publishing`](https://docs.zizmor.sh/audits/#use-trusted-publishing)).

Existing findings are intentionally **not** fixed in this PR — they will show up as code scanning alerts once this merges and can be triaged/fixed from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security analysis workflow to the CI/CD pipeline with least-privilege access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->