### PR TITLE
🔒 fix zizmor findings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,8 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: 🔎 checking for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # required for MinVer
+          persist-credentials: false
 
       - name: setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-test-publish.yml
@@ -19,6 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: global.json
+          persist-credentials: false
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:


### PR DESCRIPTION
Fixes all actionable findings from the org-wide [zizmor](https://docs.zizmor.sh/) baseline run.

## What was fixed

### [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) (3 medium)
Checkout steps persisted credentials into the workspace by default. Added `persist-credentials: false` to:
- `build-and-test.yml` — checkout in the `changes` job
- `build-test-publish.yml` — checkout in the `build-test-publish` job
- `publish.yml` — checkout in the `publish` job

### [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions) (2 medium)
`publish.yml` had no `permissions:` block, so both the workflow and the `build-and-test` reusable-workflow job ran with the default (overly broad) token permissions. Added top-level `permissions: {}`, matching the pattern already used in `build-and-test.yml` (and in the sibling Blazor.Map repo). The `publish` job keeps its existing explicit `contents: read` grant; the `build-and-test` job inherits `{}`, same as when the reusable workflow is called from `build-and-test.yml`.

## zizmor results

| | informational | low | medium | high |
|---|---|---|---|---|
| before | 1 | 0 | 5 | 0 |
| after | 1 | 0 | 0 | 0 |

The single remaining finding is the informational [`use-trusted-publishing`](https://docs.zizmor.sh/audits/#use-trusted-publishing) on the NuGet push step, which is intentionally deferred — migration to trusted publishing is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to disable credential persistence across build, test, and publish workflows.
  * Added permission constraints to publishing workflows for enhanced security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->